### PR TITLE
Add a query parameter to /questions endpoint

### DIFF
--- a/src/main/java/ch/heigvd/amt/stack/application/question/query/QuestionQuery.java
+++ b/src/main/java/ch/heigvd/amt/stack/application/question/query/QuestionQuery.java
@@ -1,7 +1,10 @@
 package ch.heigvd.amt.stack.application.question.query;
 
+import lombok.Builder;
 import lombok.Value;
 
+@Builder
 @Value
 public class QuestionQuery {
+    String shouldContain;
 }

--- a/src/main/java/ch/heigvd/amt/stack/infrastructure/persistence/memory/InMemoryQuestionRepository.java
+++ b/src/main/java/ch/heigvd/amt/stack/infrastructure/persistence/memory/InMemoryQuestionRepository.java
@@ -6,11 +6,26 @@ import ch.heigvd.amt.stack.domain.question.QuestionId;
 import ch.heigvd.amt.stack.domain.question.QuestionRepository;
 
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 public class InMemoryQuestionRepository extends InMemoryRepository<Question, QuestionId> implements QuestionRepository {
 
     @Override
     public Collection<Question> findBy(QuestionQuery query) {
-        return findAll();
+        if (query.getShouldContain() != null) {
+            return findAll().stream()
+                    .filter(question -> (
+                            question.getTitle() != null && question.getTitle()
+                                    .toLowerCase()
+                                    .contains(query.getShouldContain().toLowerCase())
+                    ) || (
+                            question.getDescription() != null && question.getDescription()
+                                    .toLowerCase()
+                                    .contains(query.getShouldContain().toLowerCase())
+                    ))
+                    .collect(Collectors.toList());
+        } else {
+            return findAll();
+        }
     }
 }

--- a/src/main/java/ch/heigvd/amt/stack/ui/web/views/question/QuestionListView.java
+++ b/src/main/java/ch/heigvd/amt/stack/ui/web/views/question/QuestionListView.java
@@ -26,7 +26,12 @@ public class QuestionListView extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        QuestionListDTO questions = facade.getQuestions(new QuestionQuery());
+        var builder = QuestionQuery.builder();
+        var query = req.getParameter("search");
+        if (query != null) {
+            builder.shouldContain(query);
+        }
+        QuestionListDTO questions = facade.getQuestions(builder.build());
         req.setAttribute("questions", questions);
         req.getRequestDispatcher("WEB-INF/views/questions.jsp").forward(req, resp);
     }


### PR DESCRIPTION
This still requires some work on the frontend / JSP side to support the feature. To search for questions containing a certain string, use the `/questions?search=Something` page.