### PR TITLE
Add hover over delete button

### DIFF
--- a/src/main/webapp/WEB-INF/views/fragments/answer.jsp
+++ b/src/main/webapp/WEB-INF/views/fragments/answer.jsp
@@ -71,7 +71,7 @@
                     <input type="hidden" name="answer" value="<c:out value="${answer.id.toString()}"/>"/>
                     <div class="flex flex-row">
                         <input type="image" src="${pageContext.request.contextPath}/assets/delete.svg" alt="delete">
-                        <input class=" ml-1 bg-transparent font-semibold text-red-500 hover:text-red-600" type="submit" value="Delete"/>
+                        <input class="ml-1 bg-transparent font-semibold text-red-500 hover:text-red-600 cursor-pointer" type="submit" value="Delete"/>
                     </div>
                 </form>
             </c:if>


### PR DESCRIPTION
This will fix #135 

Apparently, `hover:cursor-pointer` does nothing because we're supposed to edit the `tailwind.config.js` file, which we do not use. Using `https://unpkg.com/tailwindcss@^1.0/dist/tailwind.css` instead of `https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css` does not change anything either.

This is why I decided to style the `input` with the `style` attribute (which is a bit ugly...)